### PR TITLE
Fixed issue 6: index out of range error

### DIFF
--- a/htmldocx/h2d.py
+++ b/htmldocx/h2d.py
@@ -232,7 +232,7 @@ class HtmlToDocx(HTMLParser):
         rows = self.get_table_rows(table_soup)
         cell_row = 0
         for row in rows:
-            cols = self.get_table_columns(table_soup, row)
+            cols = self.get_table_columns(row)
             cell_col = 0
             for col in cols:
                 cell_html = self.get_cell_html(col)
@@ -383,7 +383,7 @@ class HtmlToDocx(HTMLParser):
         # If there's a header, body, footer or direct child tr tags, add row dimensions from there
         return table_soup.select(', '.join(self.table_row_selectors), recursive=False)
 
-    def get_table_columns(self, table_soup, row):
+    def get_table_columns(self, row):
         # Get all columns for the specified row tag.
         return row.find_all(['th', 'td'], recursive=False) if row else []
 
@@ -392,7 +392,7 @@ class HtmlToDocx(HTMLParser):
         rows = self.get_table_rows(table_soup)
         # Table is either empty or has non-direct children between table and tr tags
         # Thus the row dimensions and column dimensions are assumed to be 0
-        cols = self.get_table_columns(table_soup, rows[0]) if rows else []
+        cols = self.get_table_columns(rows[0]) if rows else []
         return len(rows), len(cols)
 
     def get_tables(self):

--- a/tests/tables1.html
+++ b/tests/tables1.html
@@ -80,7 +80,7 @@
     </tr>
 </table>
 <p>Here is one that uses only thead and tfoot</p>
-</tabl>
+<table>
     <thead>
         <tr>
             <th>heading 1</th>
@@ -102,7 +102,7 @@
     </tfoot>
 </table>
 <p>Here is one that uses only tfoot and inner trs</p>
-</tabl>
+<table>
     <tr>
         <th>heading 1</th>
         <th>th 2</th>
@@ -122,7 +122,7 @@
     </tfoot>
 </table>
 <p>Here is one that uses only tfoot</p>
-</tabl>
+<table>
     <tfoot>
         <tr>
             <td>cell 1</td>

--- a/tests/tables1.html
+++ b/tests/tables1.html
@@ -17,6 +17,125 @@
         <td>cell 6</td>
     </tr>
 </table>
+<p>Here is one that uses tbody and thead</p>
+<table>
+    <thead>
+        <tr>
+            <th>heading 1</th>
+            <th>th 2</th>
+            <th>th 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>cell 1</td>
+            <td>cell 2</td>
+            <td>cell 3</td>
+        </tr>
+        <tr>
+            <td><em>a special</em>cell 4</td>
+            <td>cell 5</td>
+            <td>cell 6</td>
+        </tr>
+    </tbody>
+</table>
+<p>Here is one that uses only tbody and not thead</p>
+<table>
+    <tr>
+        <th>heading 1</th>
+        <th>th 2</th>
+        <th>th 3</th>
+    </tr>
+    <tbody>
+        <tr>
+            <td>cell 1</td>
+            <td>cell 2</td>
+            <td>cell 3</td>
+        </tr>
+        <tr>
+            <td><em>a special</em>cell 4</td>
+            <td>cell 5</td>
+            <td>cell 6</td>
+        </tr>
+    </tbody>
+</table>
+<p>Here is one that uses only thead and not tbody</p>
+<table>
+    <thead>
+        <tr>
+            <th>heading 1</th>
+            <th>th 2</th>
+            <th>th 3</th>
+        </tr>
+    </thead>
+    <tr>
+        <td>cell 1</td>
+        <td>cell 2</td>
+        <td>cell 3</td>
+    </tr>
+    <tr>
+        <td><em>a special</em>cell 4</td>
+        <td>cell 5</td>
+        <td>cell 6</td>
+    </tr>
+</table>
+<p>Here is one that uses only thead and tfoot</p>
+</tabl>
+    <thead>
+        <tr>
+            <th>heading 1</th>
+            <th>th 2</th>
+            <th>th 3</th>
+        </tr>
+    </thead>
+    <tfoot>
+        <tr>
+            <td>cell 1</td>
+            <td>cell 2</td>
+            <td>cell 3</td>
+        </tr>
+        <tr>
+            <td><em>a special</em>cell 4</td>
+            <td>cell 5</td>
+            <td>cell 6</td>
+        </tr>
+    </tfoot>
+</table>
+<p>Here is one that uses only tfoot and inner trs</p>
+</tabl>
+    <tr>
+        <th>heading 1</th>
+        <th>th 2</th>
+        <th>th 3</th>
+    </tr>
+    <tfoot>
+        <tr>
+            <td>cell 1</td>
+            <td>cell 2</td>
+            <td>cell 3</td>
+        </tr>
+        <tr>
+            <td><em>a special</em>cell 4</td>
+            <td>cell 5</td>
+            <td>cell 6</td>
+        </tr>
+    </tfoot>
+</table>
+<p>Here is one that uses only tfoot</p>
+</tabl>
+    <tfoot>
+        <tr>
+            <td>cell 1</td>
+            <td>cell 2</td>
+            <td>cell 3</td>
+        </tr>
+        <tr>
+            <td><em>a special</em>cell 4</td>
+            <td>cell 5</td>
+            <td>cell 6</td>
+        </tr>
+    </tfoot>
+</table>
 
 Here is another table. This one has formatting.
 <s>


### PR DESCRIPTION
Fixed an issue with tables where non-direct tr children of table tag causes errors. Especially notable when the common practice of using "thead" and "tbody" tags is used.