### PR TITLE
Don't bug out on issue 10 events

### DIFF
--- a/htmldocx/h2d.py
+++ b/htmldocx/h2d.py
@@ -134,7 +134,7 @@ class HtmlToDocx(HTMLParser):
         if 'margin-left' in style:
             margin = style['margin-left']
             units = re.sub(r'[0-9]+', '', margin)
-            margin = int(re.sub(r'[a-z]+', '', margin))
+            margin = int(float(re.sub(r'[a-z]+', '', margin)))
             if units == 'px':
                 self.paragraph.paragraph_format.left_indent = Inches(min(margin // 10 * INDENT, MAX_INDENT))
             # TODO handle non px units
@@ -144,18 +144,26 @@ class HtmlToDocx(HTMLParser):
             if 'rgb' in style['color']:
                 color = re.sub(r'[a-z()]+', '', style['color'])
                 colors = [int(x) for x in color.split(',')]
-            else:
+            elif '#' in style['color']:
                 color = style['color'].lstrip('#')
                 colors = tuple(int(color[i:i+2], 16) for i in (0, 2, 4))
+            else:
+                colors = [0, 0, 0]
+                # TODO map colors to named colors (and extended colors...)
+                # For now set color to black to prevent crashing
             self.run.font.color.rgb = RGBColor(*colors)
             
         if 'background-color' in style:
             if 'rgb' in style['background-color']:
                 color = color = re.sub(r'[a-z()]+', '', style['background-color'])
                 colors = [int(x) for x in color.split(',')]
-            else:
+            elif '#' in style['background-color']:
                 color = style['background-color'].lstrip('#')
                 colors = tuple(int(color[i:i+2], 16) for i in (0, 2, 4))
+            else:
+                colors = [0, 0, 0]
+                # TODO map colors to named colors (and extended colors...)
+                # For now set color to black to prevent crashing
             self.run.font.highlight_color = WD_COLOR.GRAY_25 #TODO: map colors
 
     def parse_dict_string(self, string, separator=';'):

--- a/tests/text1.html
+++ b/tests/text1.html
@@ -1,8 +1,10 @@
 <p>My line <span width="10" style="color: rgb(235, 107, 86);">goes he</span>re</p>
 <p><span style="background-color: rgb(251, 160, 38);">Background color in RGB</span></p>
 <p><span style="background-color: #f39e65;">Background color in Hex</span></p>
+<p><span style="background-color: orange;">Background color as name</span></p>
 <p><span style="color: rgb(161, 145, 231);">Forecolor in RGB</span></p>
 <p><span style="color: #9488da;">Forecolor in Hex</span></p>
+<p><span style="color: mediumpurple;">Forecolor as name</span></p>
 <p><span style="background-color: rgb(71, 85, 119); color: rgb(255, 255, 255);">This sentence has background
         and&nbsp;</span><span style="background-color: rgb(71, 85, 119);"><span style="color: rgb(247, 218, 100);">text
             color</span><span style="color: rgb(100, 100, 100);">&nbsp;</span></span><span
@@ -37,6 +39,7 @@
 <p style="text-align: justify; margin-left: 60px;">Indent 3</p>
 <p style="text-align: justify; margin-left: 80px;">Indent 4</p>
 <p style="text-align: justify; margin-left: 580px;">Indent max?</p>
+<p style="text-align: justify; margin-left: 2.5em;">Indent 2.5em</p>
 <p style="text-align: left;">asdfsa</p>
 <p style="text-align: left;"><a class="fr-green fr-strong" href="abc://def.ghi" rel="noopener noreferrer"
         target="_blank">link</a></p>


### PR DESCRIPTION
Prevent crashing when
- margin-left references a float value, however no indenting will 
- colors are specified by names
Won't actually perform the correct formatting (no indenting will be applied for non px units, named colors will default to black), but at least shouldn't break when these are encountered.