### PR TITLE
Add support for styled tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,23 @@ from htmldocx import HtmlToDocx
 new_parser = HtmlToDocx()
 docx = new_parser.parse_html_string(input_html_file_string)
 ```
+
+Change table styles
+
+Tables are not styled by default. Use the `table_style` attribute on the parser to set a table
+style. The style is used for all tables.
+
+```
+from htmldocx import HtmlToDocx
+
+new_parser = HtmlToDocx()
+new_parser.table_style = 'Light Shading Accent 4'
+```
+
+To add borders to tables, use the `TableGrid` style:
+
+```
+new_parser.table_style = 'TableGrid'
+```
+
+Default table styles can be found here: https://python-docx.readthedocs.io/en/latest/user/styles-understanding.html#table-styles-in-default-template

--- a/htmldocx/h2d.py
+++ b/htmldocx/h2d.py
@@ -30,6 +30,9 @@ INDENT = 0.25
 LIST_INDENT = 0.5
 MAX_INDENT = 5.5 # To stop indents going off the page
 
+# Style to use with tables. By default no style is used.
+DEFAULT_TABLE_STYLE = None
+
 def get_filename_from_url(url):
     return os.path.basename(urlparse(url).path)
 
@@ -96,6 +99,7 @@ class HtmlToDocx(HTMLParser):
             'table > tbody > tr',
             'table > tfoot > tr'
         ]
+        self.table_style = DEFAULT_TABLE_STYLE
 
     def set_initial_attrs(self, document=None):
         self.tags = {
@@ -115,6 +119,10 @@ class HtmlToDocx(HTMLParser):
         self.skip = False
         self.skip_tag = None
         self.instances_to_skip = 0
+
+    def copy_settings_from(self, other):
+        """Copy settings from another instance of HtmlToDocx"""
+        self.table_style = other.table_style
 
     def get_cell_html(self, soup):
         # Returns string of td element with opening and closing <td> tags removed
@@ -237,6 +245,13 @@ class HtmlToDocx(HTMLParser):
         table_soup = self.tables[self.table_no]
         rows, cols = self.get_table_dimensions(table_soup)
         self.table = self.doc.add_table(rows, cols)
+
+        if self.table_style:
+            try:
+                self.table.style = self.table_style
+            except KeyError as e:
+                raise ValueError(f"Unable to apply style {self.table_style}.") from e
+
         rows = self.get_table_rows(table_soup)
         cell_row = 0
         for row in rows:
@@ -248,6 +263,7 @@ class HtmlToDocx(HTMLParser):
                     cell_html = "<b>%s</b>" % cell_html
                 docx_cell = self.table.cell(cell_row, cell_col)
                 child_parser = HtmlToDocx()
+                child_parser.copy_settings_from(self)
                 child_parser.add_html_to_cell(cell_html, docx_cell)
                 cell_col += 1
             cell_row += 1

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,19 +1,24 @@
 import os
+from pathlib import Path
 import unittest
 from docx import Document
 from .context import HtmlToDocx, test_dir
 
 class OutputTest(unittest.TestCase):
 
+    @staticmethod
+    def get_html_from_file(filename: str):
+        file_path = Path(test_dir) / Path(filename)
+        with open(file_path, 'r') as f:
+            html = f.read()
+        return html
+
     @classmethod
     def setUpClass(cls):
         cls.document = Document()
-        textpath = os.path.join(test_dir, 'text1.html')
-        tablepath = os.path.join(test_dir, 'tables1.html')
-        with open(textpath, 'r') as tb:
-            cls.text1 = tb.read()
-        with open(tablepath, 'r') as tb:
-            cls.table_html = tb.read()
+        cls.text1 = cls.get_html_from_file('text1.html')
+        cls.table_html = cls.get_html_from_file('tables1.html')
+        cls.table2_html = cls.get_html_from_file('tables2.html')
 
     @classmethod
     def tearDownClass(cls):
@@ -53,6 +58,40 @@ class OutputTest(unittest.TestCase):
             level=1
         )
         self.parser.add_html_to_document(self.table_html, self.document)
+
+    def test_add_html_with_tables_accent_style(self):
+        self.document.add_heading(
+            'Test: add html with tables with accent',
+        )
+        self.parser.table_style = 'Light Grid Accent 6'
+        self.parser.add_html_to_document(self.table_html, self.document)
+
+    def test_add_html_with_tables_basic_style(self):
+        self.document.add_heading(
+            'Test: add html with tables with basic style',
+        )
+        self.parser.table_style = 'TableGrid'
+        self.parser.add_html_to_document(self.table_html, self.document)
+
+    def test_add_nested_tables(self):
+        self.document.add_heading(
+            'Test: add nested tables',
+        )
+        self.parser.add_html_to_document(self.table2_html, self.document)
+
+    def test_add_nested_tables_basic_style(self):
+        self.document.add_heading(
+            'Test: add nested tables with basic style',
+        )
+        self.parser.table_style = 'TableGrid'
+        self.parser.add_html_to_document(self.table2_html, self.document)
+
+    def test_add_nested_tables_accent_style(self):
+        self.document.add_heading(
+            'Test: add nested tables with accent style',
+        )
+        self.parser.table_style = 'Light Grid Accent 6'
+        self.parser.add_html_to_document(self.table2_html, self.document)
 
     def test_add_html_skip_tables(self):
         # broken until feature readded


### PR DESCRIPTION
Allow table style to be changed by setting `table_style` attribute on the
HtmlToDocx instance.

The default table style is set to `None` to ensure the behavior doesn't change between versions.

Available default styles can be found [here](https://python-docx.readthedocs.io/en/latest/user/styles-understanding.html#table-styles-in-default-template)

# Example usage:

## Without styling

This is the default (current) behavior. This is the same as using `d.table_style=None`:

> ![image](https://user-images.githubusercontent.com/30441316/126686168-d5f1c18b-286b-49dc-8178-7435ea884161.png)

## With basic grid style:

```python
d = HtmlToDocx()

# Use simple grid style (which just adds borders to table)
d.table_style = 'TableGrid'
```
> ![image](https://user-images.githubusercontent.com/30441316/126686838-bdef12cc-4ccb-439e-9b3c-b8cc0000f06f.png)

## With colored style

```python
d = HtmlToDocx()

# Use the Light Grid Accent 6 table style
d.table_style = 'Light Grid Accent 6'
```

> ![image](https://user-images.githubusercontent.com/30441316/126686926-ec9f466d-733d-49c1-ba10-4477f798872b.png)

# Other changes
Update manual test to use table style.

Add documentation to the readme.

In order to allow nested tables to use the same style we need to pass the table style to the new child table. I did this by creating a function that can be used to copy attributes from one parser instance to the next. There are other ways to do this that might be more pythonic, but this was a quick and simple way that can act as a placeholder.