### PR TITLE
Add handling for pre and code blocks

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,6 +35,8 @@ jobs:
       run: |
         python -m tests.test
         python -m tests.test_tables
+        python -m tests.test_code
+        python -m doctest -v htmldocx/h2d.py
     - name: Upload test artifacts
       uses: actions/upload-artifact@v2.2.0
       with:

--- a/tests/code.html
+++ b/tests/code.html
@@ -1,0 +1,27 @@
+<h1>Code Test</h1>
+
+<p>This test validates handling of code blocks.</p>
+
+<h2>Pre-formatted block</h2>
+
+<pre>
+This is a pre-formatted block.
+  That should be pre-formatted.
+Retaining any carriage returns, and     all    white    space.
+
+And blank lines.
+</pre>
+
+<h2>Code block</h2>
+
+<p><code>
+This is a code block.
+  That should be NOT be pre-formatted.
+It should NOT retain carriage returns, or     all    white    space.
+
+or blank lines.
+</code></p>
+
+<h2>Code elements</h2>
+
+<p>This is a sentence that includes <code>code</code> elements.</p>

--- a/tests/test.py
+++ b/tests/test.py
@@ -95,5 +95,47 @@ class OutputTest(unittest.TestCase):
         html = '''<p>Line 0 with p tags</p>Line 1 without p tags'''
         self.parser.add_html_to_cell(html, cell)
 
+    def test_inline_code(self):
+        self.document.add_heading(
+            'Test: inline code block',
+            level=1
+        )
+
+        html = "<p>This is a sentence that contains <code>some code elements</code> that " \
+               "should appear as code.</p>"
+        self.parser.add_html_to_document(html, self.document)
+
+    def test_code_block(self):
+        self.document.add_heading(
+            'Test: code block',
+            level=1
+        )
+
+        html = """<p><code>
+This is a code block.
+  That should be NOT be pre-formatted.
+It should NOT retain carriage returns,
+
+or blank lines.
+</code></p>"""
+        self.parser.add_html_to_document(html, self.document)
+
+    def test_pre_block(self):
+        self.document.add_heading(
+            'Test: pre block',
+            level=1
+        )
+
+        html = """<pre>
+This is a pre-formatted block.
+  That should be pre-formatted.
+Retaining any carriage returns,
+
+and blank lines.
+</pre>
+"""
+        self.parser.add_html_to_document(html, self.document)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -1,0 +1,9 @@
+import os
+from .context import HtmlToDocx, test_dir
+
+# Manual test (requires inspection of result) for converting code and pre blocks.
+
+filename = os.path.join(test_dir, 'code.html')
+d = HtmlToDocx()
+
+d.parse_html_file(filename)


### PR DESCRIPTION
* `<pre>` and `<code>` blocks use Courier font
* `<pre>` blocks retain white space and new line characters.

Add manual test for code blocks (similar to the tables test). Run this manually to validate visual representation of code and pre-formatted blocks.

Remove calls to `remove_whitespace()` from `run_process()`. This is now called from `handle_data()` when not in a pre block.

Test HTML:

```
<h1>Code Test</h1>

<p>This test validates handling of code blocks.</p>

<h2>Pre-formatted block</h2>

<pre>
This is a pre-formatted block.
  That should be pre-formatted.
Retaining any carriage returns, and     all    white    space.

And blank lines.
</pre>

<h2>Code block</h2>

<p><code>
This is a code block.
  That should be NOT be pre-formatted.
It should NOT retain carriage returns, or     all    white    space.

or blank lines.
</code></p>

<h2>Code elements</h2>

<p>This is a sentence that includes <code>code</code> elements.</p>
```

In HTML, this renders like this:

> ![image](https://user-images.githubusercontent.com/30441316/126685552-d472ae03-f7c8-42a5-9e84-8f0b65d40bd5.png)

The resulting Word doc looks like this:

> ![image](https://user-images.githubusercontent.com/30441316/126685664-0204656e-23ef-4df4-9668-48ddc2c6659d.png)
