### PR TITLE
Move list styles to dict

### DIFF
--- a/htmldocx/h2d.py
+++ b/htmldocx/h2d.py
@@ -80,6 +80,11 @@ fonts = {
     'th': 'bold',
 }
 
+styles = {
+    'LIST_BULLET': 'List Bullet',
+    'LIST_NUMBER': 'List Number',
+}
+
 class HtmlToDocx(HTMLParser):
 
     def __init__(self):
@@ -180,9 +185,9 @@ class HtmlToDocx(HTMLParser):
             list_type = 'ul' # assign unordered if no tag
 
         if list_type == 'ol':
-            list_style = "List Number"
+            list_style = styles['LIST_NUMBER']
         else:
-            list_style = 'List Bullet'
+            list_style = styles['LIST_BULLET']
 
         self.paragraph = self.doc.add_paragraph(style=list_style)            
         self.paragraph.paragraph_format.left_indent = Inches(min(list_depth * LIST_INDENT, MAX_INDENT))


### PR DESCRIPTION
Move list styles into a dict so that they can be overridden if needed. 

Some documents use different names for list styles (for example, other languages), some documents don't have the default styles present, and in some instances users might want to use different styles for lists.

This approach allows users to modify the contents of `htmldocx.h2d.styles` to their own preference.

For example:

```python
import htmldocx
htmldocx.h2d.styles['LIST_NUMBER'] = 'My Custom Numbered List'
```

The reason I am requesting this change is because I am working with template documents that don't contain the "List Number" and "List Bullet" styles. This doesn't need to be a documented feature, it would just enable me to make use of this package using my templates.