### PR TITLE
Do not delete content of a non-empty cell.

### DIFF
--- a/htmldocx/h2d.py
+++ b/htmldocx/h2d.py
@@ -594,7 +594,8 @@ class HtmlToDocx(HTMLParser):
         if not isinstance(cell, docx.table._Cell):
             raise ValueError('Second argument needs to be a %s' % docx.table._Cell)
         unwanted_paragraph = cell.paragraphs[0]
-        delete_paragraph(unwanted_paragraph)
+        if unwanted_paragraph.text == "":
+            delete_paragraph(unwanted_paragraph)
         self.set_initial_attrs(cell)
         self.run_process(html)
         # cells must end with a paragraph or will get message about corrupt file

--- a/tests/test.py
+++ b/tests/test.py
@@ -125,13 +125,18 @@ class OutputTest(unittest.TestCase):
             'Test: add_html_to_cells method',
             level=1
         )
-        table = self.document.add_table(2,2, style='Table Grid')
-        cell = table.cell(0,0)
+        table = self.document.add_table(2, 3, style='Table Grid')
+        cell = table.cell(0, 0)
         html = '''Line 0 without p tags<p>Line 1 with P tags</p>'''
         self.parser.add_html_to_cell(html, cell)
 
-        cell = table.cell(0,1)
+        cell = table.cell(0, 1)
         html = '''<p>Line 0 with p tags</p>Line 1 without p tags'''
+        self.parser.add_html_to_cell(html, cell)
+
+        cell = table.cell(0, 2)
+        cell.text = "Pre-defined text that shouldn't be removed."
+        html = '''<p>Add HTML to non-empty cell.</p>'''
         self.parser.add_html_to_cell(html, cell)
 
     def test_inline_code(self):


### PR DESCRIPTION
When using `add_html_to_cell`, the function to delete an unwanted
paragraph should only be called if the paragraph is indeed unwanted,
i.e. if it is an empty paragraph automatically created when the cell
was created.