### PR TITLE
Implement default paragraph style

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,22 @@ To add borders to tables, use the `TableGrid` style:
 new_parser.table_style = 'TableGrid'
 ```
 
-Default table styles can be found here: https://python-docx.readthedocs.io/en/latest/user/styles-understanding.html#table-styles-in-default-template
+Default table styles can be found
+here: https://python-docx.readthedocs.io/en/latest/user/styles-understanding.html#table-styles-in-default-template
+
+Change default paragraph style
+
+No style is applied to the paragraphs by default. Use the `paragraph_style` attribute on the parser
+to set a default paragraph style. The style is used for all paragraphs. If additional styling (
+color, background color, alignment...) is defined in the HTML, it will be applied after the
+paragraph style.
+
+```
+from htmldocx import HtmlToDocx
+
+new_parser = HtmlToDocx()
+new_parser.paragraph_style = 'Quote'
+```
+
+Default paragraph styles can be found
+here: https://python-docx.readthedocs.io/en/latest/user/styles-understanding.html#paragraph-styles-in-default-template

--- a/tests/test.py
+++ b/tests/test.py
@@ -35,6 +35,24 @@ class OutputTest(unittest.TestCase):
         )
         self.parser.add_html_to_document(self.text1, self.document)
 
+    def test_html_with_default_paragraph_style(self):
+        self.document.add_heading(
+            'Test: add regular html with a default paragraph style defined',
+            level=1
+        )
+        self.parser.paragraph_style = 'Quote'
+        self.parser.add_html_to_document(self.text1, self.document)
+
+    def test_add_html_to_table_cell_with_default_paragraph_style(self):
+        self.document.add_heading(
+            'Test: regular html to table cell with a default paragraph style defined',
+            level=1
+        )
+        self.parser.paragraph_style = 'Quote'
+        table = self.document.add_table(2, 2, style='Table Grid')
+        cell = table.cell(1, 1)
+        self.parser.add_html_to_document(self.text1, cell)
+
     def test_add_html_to_table_cell(self):
         self.document.add_heading(
             'Test: regular html with images, links, some formatting to table cell',


### PR DESCRIPTION
Inspired by #16 

Allow paragraph style to be changed by setting paragraph_style attribute on the HtmlToDocx instance.

The default paragraph style is set to None to ensure the behavior doesn't change between versions.

Available default styles can be found here: https://python-docx.readthedocs.io/en/latest/user/styles-understanding.html#paragraph-styles-in-default-template

Example usage:

```python
parser = HtmlToDocx()
parser.paragraph_style = 'Quote'
```