### PR TITLE
Image styles - alignments + dimension(pixel/pt only)

### DIFF
--- a/htmldocx/h2d.py
+++ b/htmldocx/h2d.py
@@ -25,6 +25,7 @@ from docx.shared import RGBColor, Pt, Inches
 from docx.enum.text import WD_COLOR, WD_ALIGN_PARAGRAPH
 from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
+from docx.shared import Pt
 
 from bs4 import BeautifulSoup
 
@@ -306,11 +307,11 @@ class HtmlToDocx(HTMLParser):
         self.paragraph.paragraph_format.left_indent = Inches(min(list_depth * LIST_INDENT, MAX_INDENT))
         self.paragraph.paragraph_format.line_spacing = 1
 
-    def add_image_to_cell(self, cell, image):
+    def add_image_to_cell(self, cell, image,width,height):
         # python-docx doesn't have method yet for adding images to table cells. For now we use this
         paragraph = cell.add_paragraph()
         run = paragraph.add_run()
-        run.add_picture(image)
+        run.add_picture(image,width,height)
 
     def handle_img(self, current_attrs):
         if not self.include_images:
@@ -318,6 +319,9 @@ class HtmlToDocx(HTMLParser):
             self.skip_tag = 'img'
             return
         src = current_attrs['src']
+        # added image dimension, interpreting values as pixel only
+        height = Pt(int(current_attrs['height'][:-2])) if 'height' in current_attrs else None
+        width = Pt(int(current_attrs['width'][:-2])) if 'width' in current_attrs else None
         # fetch image
         src_is_url = is_url(src)
         if src_is_url:
@@ -331,9 +335,9 @@ class HtmlToDocx(HTMLParser):
         if image:
             try:
                 if isinstance(self.doc, docx.document.Document):
-                    self.doc.add_picture(image)
+                    self.doc.add_picture(image,width,height)
                 else:
-                    self.add_image_to_cell(self.doc, image)
+                    self.add_image_to_cell(self.doc, image,width,height)
             except FileNotFoundError:
                 image = None
         if not image:

--- a/htmldocx/h2d.py
+++ b/htmldocx/h2d.py
@@ -31,7 +31,7 @@ from bs4 import BeautifulSoup
 # values in inches
 INDENT = 0.25
 LIST_INDENT = 0.5
-MAX_INDENT = 5.5 # To stop indents going off the page
+MAX_INDENT = 5.5  # To stop indents going off the page
 
 # Style to use with tables. By default no style is used.
 DEFAULT_TABLE_STYLE = None
@@ -43,6 +43,7 @@ DEFAULT_PARAGRAPH_STYLE = None
 def get_filename_from_url(url):
     return os.path.basename(urlparse(url).path)
 
+
 def is_url(url):
     """
     Not to be used for actually validating a url, but in our use case we only 
@@ -50,6 +51,7 @@ def is_url(url):
     """
     parts = urlparse(url)
     return all([parts.scheme, parts.netloc, parts.path])
+
 
 def fetch_image(url):
     """
@@ -65,8 +67,10 @@ def fetch_image(url):
     except urllib.error.URLError:
         return None
 
+
 def remove_last_occurence(ls, x):
     ls.pop(len(ls) - ls[::-1].index(x) - 1)
+
 
 def remove_whitespace(string, leading=False, trailing=False):
     """Remove white space from a string.
@@ -133,6 +137,7 @@ def remove_whitespace(string, leading=False, trailing=False):
     # TODO need some way to get rid of extra spaces in e.g. text <span>   </span>  text
     return re.sub(r'\s+', ' ', string)
 
+
 def delete_paragraph(paragraph):
     # https://github.com/python-openxml/python-docx/issues/33#issuecomment-77661907
     p = paragraph._element
@@ -176,6 +181,7 @@ styles = {
     'LIST_NUMBER': 'List Number',
 }
 
+
 class HtmlToDocx(HTMLParser):
 
     def __init__(self):
@@ -204,9 +210,9 @@ class HtmlToDocx(HTMLParser):
             self.doc = document
         else:
             self.doc = Document()
-        self.bs = self.options['fix-html'] # whether or not to clean with BeautifulSoup
+        self.bs = self.options['fix-html']  # whether or not to clean with BeautifulSoup
         self.document = self.doc
-        self.include_tables = True #TODO add this option back in?
+        self.include_tables = True  # TODO add this option back in?
         self.include_images = self.options['images']
         self.include_styles = self.options['styles']
         self.paragraph = None
@@ -249,7 +255,7 @@ class HtmlToDocx(HTMLParser):
                 colors = [int(x) for x in color.split(',')]
             elif '#' in style['color']:
                 color = style['color'].lstrip('#')
-                colors = tuple(int(color[i:i+2], 16) for i in (0, 2, 4))
+                colors = tuple(int(color[i:i + 2], 16) for i in (0, 2, 4))
             else:
                 colors = [0, 0, 0]
                 # TODO map colors to named colors (and extended colors...)
@@ -262,12 +268,12 @@ class HtmlToDocx(HTMLParser):
                 colors = [int(x) for x in color.split(',')]
             elif '#' in style['background-color']:
                 color = style['background-color'].lstrip('#')
-                colors = tuple(int(color[i:i+2], 16) for i in (0, 2, 4))
+                colors = tuple(int(color[i:i + 2], 16) for i in (0, 2, 4))
             else:
                 colors = [0, 0, 0]
                 # TODO map colors to named colors (and extended colors...)
                 # For now set color to black to prevent crashing
-            self.run.font.highlight_color = WD_COLOR.GRAY_25 #TODO: map colors
+            self.run.font.highlight_color = WD_COLOR.GRAY_25  # TODO: map colors
 
     def apply_paragraph_style(self, style=None):
         try:
@@ -289,7 +295,7 @@ class HtmlToDocx(HTMLParser):
         if list_depth:
             list_type = self.tags['list'][-1]
         else:
-            list_type = 'ul' # assign unordered if no tag
+            list_type = 'ul'  # assign unordered if no tag
 
         if list_type == 'ol':
             list_style = styles['LIST_NUMBER']
@@ -404,7 +410,6 @@ class HtmlToDocx(HTMLParser):
         hyperlink = docx.oxml.shared.OxmlElement('w:hyperlink')
         hyperlink.set(docx.oxml.shared.qn('r:id'), rel_id)
 
-
         # Create sub-run
         subrun = self.paragraph.add_run()
         rPr = docx.oxml.shared.OxmlElement('w:rPr')
@@ -446,7 +451,7 @@ class HtmlToDocx(HTMLParser):
             return
         elif tag == 'ol' or tag == 'ul':
             self.tags['list'].append(tag)
-            return # don't apply styles for now
+            return  # don't apply styles for now
         elif tag == 'br':
             self.run.add_break()
             return
@@ -468,14 +473,14 @@ class HtmlToDocx(HTMLParser):
             pPr = self.paragraph._p.get_or_add_pPr()
             pBdr = OxmlElement('w:pBdr')
             pPr.insert_element_before(pBdr,
-                'w:shd', 'w:tabs', 'w:suppressAutoHyphens', 'w:kinsoku', 'w:wordWrap',
-                'w:overflowPunct', 'w:topLinePunct', 'w:autoSpaceDE', 'w:autoSpaceDN',
-                'w:bidi', 'w:adjustRightInd', 'w:snapToGrid', 'w:spacing', 'w:ind',
-                'w:contextualSpacing', 'w:mirrorIndents', 'w:suppressOverlap', 'w:jc',
-                'w:textDirection', 'w:textAlignment', 'w:textboxTightWrap',
-                'w:outlineLvl', 'w:divId', 'w:cnfStyle', 'w:rPr', 'w:sectPr',
-                'w:pPrChange'
-            )
+                                      'w:shd', 'w:tabs', 'w:suppressAutoHyphens', 'w:kinsoku', 'w:wordWrap',
+                                      'w:overflowPunct', 'w:topLinePunct', 'w:autoSpaceDE', 'w:autoSpaceDN',
+                                      'w:bidi', 'w:adjustRightInd', 'w:snapToGrid', 'w:spacing', 'w:ind',
+                                      'w:contextualSpacing', 'w:mirrorIndents', 'w:suppressOverlap', 'w:jc',
+                                      'w:textDirection', 'w:textAlignment', 'w:textboxTightWrap',
+                                      'w:outlineLvl', 'w:divId', 'w:cnfStyle', 'w:rPr', 'w:sectPr',
+                                      'w:pPrChange'
+                                      )
             bottom = OxmlElement('w:bottom')
             bottom.set(qn('w:val'), 'single')
             bottom.set(qn('w:sz'), '6')
@@ -664,8 +669,8 @@ class HtmlToDocx(HTMLParser):
         self.run_process(html)
         return self.doc
 
-if __name__=='__main__':
 
+if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser(description='Convert .html file into .docx file with formatting')
     arg_parser.add_argument('filename_html', help='The .html file to be parsed')
     arg_parser.add_argument(
@@ -675,7 +680,7 @@ if __name__=='__main__':
         default=None
     )
     arg_parser.add_argument('--bs', action='store_true',
-        help='Attempt to fix html before parsing. Requires bs4. Default True')
+                            help='Attempt to fix html before parsing. Requires bs4. Default True')
 
     args = vars(arg_parser.parse_args())
     file_html = args.pop('filename_html')

--- a/htmldocx/h2d.py
+++ b/htmldocx/h2d.py
@@ -307,7 +307,7 @@ class HtmlToDocx(HTMLParser):
         self.paragraph.paragraph_format.left_indent = Inches(min(list_depth * LIST_INDENT, MAX_INDENT))
         self.paragraph.paragraph_format.line_spacing = 1
 
-    def add_image_to_cell(self, cell, image,width,height):
+    def add_image_to_cell(self, cell, image, width, height):
         # python-docx doesn't have method yet for adding images to table cells. For now we use this
         paragraph = cell.add_paragraph()
         run = paragraph.add_run()

--- a/htmldocx/h2d.py
+++ b/htmldocx/h2d.py
@@ -12,22 +12,24 @@ user can pass existing document object as arg
 
 How to deal with block level style applied over table elements? e.g. text align
 """
+import argparse
 import enum
-import re, argparse
-import io, os
+import io
+import os
+import re
 import urllib.request
-from urllib.parse import urlparse
 from html.parser import HTMLParser
+from urllib.parse import urlparse
 
-import docx, docx.table
+import docx
+import docx.table
+from bs4 import BeautifulSoup
 from docx import Document
-from docx.shared import RGBColor, Pt, Inches
 from docx.enum.text import WD_COLOR, WD_ALIGN_PARAGRAPH
 from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
 from docx.shared import Pt
-
-from bs4 import BeautifulSoup
+from docx.shared import RGBColor, Inches
 
 # values in inches
 INDENT = 0.25
@@ -311,7 +313,7 @@ class HtmlToDocx(HTMLParser):
         # python-docx doesn't have method yet for adding images to table cells. For now we use this
         paragraph = cell.add_paragraph()
         run = paragraph.add_run()
-        run.add_picture(image,width,height)
+        run.add_picture(image, width, height)
 
     def handle_img(self, current_attrs):
         if not self.include_images:
@@ -335,9 +337,9 @@ class HtmlToDocx(HTMLParser):
         if image:
             try:
                 if isinstance(self.doc, docx.document.Document):
-                    self.doc.add_picture(image,width,height)
+                    self.doc.add_picture(image, width, height)
                 else:
-                    self.add_image_to_cell(self.doc, image,width,height)
+                    self.add_image_to_cell(self.doc, image, width, height)
             except FileNotFoundError:
                 image = None
         if not image:

--- a/tests/text1.html
+++ b/tests/text1.html
@@ -17,6 +17,8 @@
 <p>A centered picture from url: <img style="display: block; margin-left: auto; margin-right: auto;" src='https://raw.githubusercontent.com/pqzx/h2d/master/testimg.png' /></p>
 <p>A right aligned picture from url: <img img style="float: right;" src='https://raw.githubusercontent.com/pqzx/h2d/master/testimg.png' /></p>
 <p>A picture from url that's broken: <img src='https://raw.githubusercontent.com/pqzx/h2d/master/fakeimg.png' /></p>
+<p>A picture with height and width: <img height="100px" width="200px" src='https://raw.githubusercontent.com/pqzx/h2d/master/testimg.png' /></p>
+<p>A picture with height and width and centered: <img style="display: block; margin-left: auto; margin-right: auto;" height="100px" width="200px" src='https://raw.githubusercontent.com/pqzx/h2d/master/testimg.png' /></p>
 <h1>heading 1</h1>
 <ol>
     <li>Ordered list first item</li>

--- a/tests/text1.html
+++ b/tests/text1.html
@@ -14,6 +14,8 @@
 <pre>2 + 3 = 5↵this is code</pre>
 <p>A picture from file: <img src='testimg.png' /></p>
 <p>A picture from url: <img src='https://raw.githubusercontent.com/pqzx/h2d/master/testimg.png' /></p>
+<p>A centered picture from url: <img style="display: block; margin-left: auto; margin-right: auto;" src='https://raw.githubusercontent.com/pqzx/h2d/master/testimg.png' /></p>
+<p>A right aligned picture from url: <img img style="float: right;" src='https://raw.githubusercontent.com/pqzx/h2d/master/testimg.png' /></p>
 <p>A picture from url that's broken: <img src='https://raw.githubusercontent.com/pqzx/h2d/master/fakeimg.png' /></p>
 <h1>heading 1</h1>
 <ol>


### PR DESCRIPTION
added style for image

        For right-alignment: `'float: right;'`
        For center-alignment: `'display: block; margin-left: auto; margin-right: auto;'`
        Everything else would be Left aligned

All tests passed, and the output looks fine, like:
![mr4](https://user-images.githubusercontent.com/29339330/147256187-fe72ccb8-bf58-4a07-b6eb-452b644adedf.PNG)
![mr1](https://user-images.githubusercontent.com/29339330/147256194-8f3a6804-1745-49fe-9a21-8fa56b81d5db.PNG)
![mr2](https://user-images.githubusercontent.com/29339330/147256196-d69a2082-4f21-4001-85a2-ef92dbfa63a8.PNG)
![mr3](https://user-images.githubusercontent.com/29339330/147256200-696eb9a0-cf13-4184-a9e1-f6a66a980861.PNG)

