### PR TITLE
Allowing for alternative encodings

### DIFF
--- a/htmldocx/h2d.py
+++ b/htmldocx/h2d.py
@@ -620,8 +620,8 @@ class HtmlToDocx(HTMLParser):
         if not self.doc.paragraphs:
             self.doc.add_paragraph('')  
 
-    def parse_html_file(self, filename_html, filename_docx=None):
-        with open(filename_html, 'r') as infile:
+    def parse_html_file(self, filename_html, filename_docx=None, encoding='utf-8'):
+        with open(filename_html, 'r', encoding=encoding) as infile:
             html = infile.read()
         self.set_initial_attrs()
         self.run_process(html)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 beautifulsoup4==4.8.0
-python-docx==0.8.10
+python-docx==0.8.11


### PR DESCRIPTION
For better language support. By default, utf-8 encoding is used.
Also using newer version of python-docx for compatibility issues with python 3.10+.