### PR TITLE
Handle img tag without src attribute

### DIFF
--- a/htmldocx/h2d.py
+++ b/htmldocx/h2d.py
@@ -295,7 +295,11 @@ class HtmlToDocx(HTMLParser):
             self.skip = True
             self.skip_tag = 'img'
             return
-        src = current_attrs['src']
+        src = current_attrs.get('src')
+        if not src:
+            self.doc.add_paragraph("<image: no_src>")
+            return
+
         # fetch image
         src_is_url = is_url(src)
         if src_is_url:

--- a/tests/test.py
+++ b/tests/test.py
@@ -205,6 +205,13 @@ and blank lines.
         )
         self.parser.add_html_to_document("<p>paragraph</p><hr><p>paragraph</p>", self.document)
 
+    def test_image_no_src(self):
+        self.document.add_heading(
+            'Test: Handling img without src',
+            level=1
+        )
+        self.parser.add_html_to_document("<img />", self.document)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix for KeyError 'src' when encountering an img tag without a src attribute.  Instead, it adds a paragraph with a placeholder, which is consistent with the other failure modes of this method.  Added a test for this case.