### PR TITLE
IndexError with colspan

### DIFF
--- a/htmldocx/h2d.py
+++ b/htmldocx/h2d.py
@@ -579,9 +579,13 @@ class HtmlToDocx(HTMLParser):
         rows = self.get_table_rows(table_soup)
         # Table is either empty or has non-direct children between table and tr tags
         # Thus the row dimensions and column dimensions are assumed to be 0
-
-        cols = self.get_table_columns(rows[0]) if rows else []
-        return len(rows), len(cols)
+        # A table can have a varying number of columns per row,
+        #     so it is important to find the maximum number of columns in any row
+        if rows:
+            cols = max(len(self.get_table_columns(row)) for row in rows)
+        else:
+            cols = 0
+        return len(rows), cols
 
     def get_tables(self):
         if not hasattr(self, 'soup'):

--- a/tests/test.py
+++ b/tests/test.py
@@ -205,6 +205,19 @@ and blank lines.
         )
         self.parser.add_html_to_document("<p>paragraph</p><hr><p>paragraph</p>", self.document)
 
+    def test_unbalanced_table(self):
+        # A table with more td elements in latter rows than in the first
+        self.document.add_heading(
+            'Test: Handling unbalanced tables',
+            level=1
+        )
+        self.parser.add_html_to_document(
+            "<table>"
+            "<tr><td>Hello</td></tr>"
+            "<tr><td>One</td><td>Two</td></tr>"
+            "</table>",
+            self.document)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix for IndexError when a table has more cells in latter rows than in the first row.