### PR TITLE
Improved inline image rendering for proper text-image alignment

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/html2docx.iml
+++ b/.idea/html2docx.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.12 (html2docx)" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.12 (html2docx)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/html2docx.iml" filepath="$PROJECT_DIR$/.idea/html2docx.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/htmldocx/h2d.py
+++ b/htmldocx/h2d.py
@@ -601,11 +601,30 @@ class HtmlToDocx(HTMLParser):
 
     def add_html_to_document(self, html, document):
         if not isinstance(html, str):
-            raise ValueError('First argument needs to be a %s' % str)
+            raise ValueError('First argument needs to be a string')
         elif not isinstance(document, docx.document.Document) and not isinstance(document, docx.table._Cell):
-            raise ValueError('Second argument needs to be a %s' % docx.document.Document)
+            raise ValueError('Second argument needs to be a Document or a Cell object')
+
         self.set_initial_attrs(document)
-        self.run_process(html)
+        soup = BeautifulSoup(html, 'html.parser')
+        self.paragraph = document.add_paragraph()
+        for element in soup.descendants:
+            if isinstance(element, str):
+                self.run = self.paragraph.add_run(element.strip())
+            elif element.name == 'img':
+
+                img_path = element.get('src')
+                width = element.get('width', 100)
+                height = element.get('height', 50)
+                self.run = self.paragraph.add_run()
+                self.run.add_picture(img_path, width=Inches(float(width) / 100), height=Inches(float(height) / 100))
+            else:
+                continue
+
+
+        paragraph_format = self.paragraph.paragraph_format
+        paragraph_format.line_spacing = 1.0
+        paragraph_format.keep_with_next = True
 
     def add_html_to_cell(self, html, cell):
         if not isinstance(cell, docx.table._Cell):

--- a/mytest.py
+++ b/mytest.py
@@ -1,0 +1,12 @@
+from docx import Document
+from htmldocx import HtmlToDocx
+
+document = Document()
+new_parser = HtmlToDocx()
+
+html = '''
+<p>there are some words：<img src="testimg.png"D:/kaiyuan/html2docx/testimg.png width="100" height="50" alt="测试图片"/>，there are some words in the same line。</p>
+'''
+
+new_parser.add_html_to_document(html, document)
+document.save('test_output.docx')


### PR DESCRIPTION

Enhanced the HTML to DOCX conversion logic to ensure that images are displayed inline with text. Adjusted the run and paragraph handling to prevent images from being placed in separate paragraphs, maintaining proper inline flow between text and images. This change ensures better formatting consistency in the output documents.
I fixed the missing run object by initializing it with self.run = self.paragraph.add_run() before inserting text or images. This ensures that images and text can be added to the same run without creating separate paragraphs. Additionally, I addressed the line spacing issue by setting paragraph_format.line_spacing = 1.0, making sure the spacing between images and text is appropriate. Furthermore, I ensured all actions remain within the same paragraph to avoid unnecessary line breaks, keeping images and text inline. I have included a test script named "mytest" for verification. Thank you for your project!     ：）